### PR TITLE
[Add]topとaboutのビューおよびジャンル検索欄の部分テンプレートデザイン(昨日は検索未実装)

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,5 +1,7 @@
 class Public::HomesController < ApplicationController
   def top
+    @new_item = Item.order('id DESC').limit(4)
+    @genres = Genre.all
   end
 
   def about

--- a/app/views/public/homes/_genre_search.html.erb
+++ b/app/views/public/homes/_genre_search.html.erb
@@ -1,0 +1,14 @@
+      <table class="border">
+        <thead>
+          <tr>
+            <th>ジャンル検索</th>
+          </tr>
+        </thead>
+        <tbody>
+      <% genres.each do |genre| %>
+        <tr>
+          <td><%= genre.name %></td>
+        </tr>
+      <% end %>
+        </tbody>
+      </table>

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,2 +1,13 @@
-<h1>Public::Homes#about</h1>
-<p>Find me in app/views/public/homes/about.html.erb</p>
+<div class="container mx-auto">
+  <div class="text-center">
+    <div>
+      <h1>About</h1>
+      <p>ながのckaeは全国発送可能なキー機屋さんです。
+      <br>お子様からお年寄りの方までお召し上がりいただけるよう、
+      <br>様々なバリエーションをご用意しております。
+      <br>また、全国へ発送可能ですので「いつ」でも「どこ」でもご注文いただけます。
+      <br>是非ご注文下さい。
+      </p>
+    </div> 
+  </div>
+</div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,2 +1,36 @@
-<h1>Public::Homes#top</h1>
-<p>Find me in app/views/public/homes/top.html.erb</p>
+<div class="container ml-5">
+  <div class="row">
+    <div class="col-md-2">
+      <%= render 'genre_search',genres: @genres %>
+    </div>
+
+    <div class="col-md-10">
+      <p class="row border">ようこそ、ながのCAKEへ!<br>
+                            このサイトは、ケーキ販売のECサイトになります<br>
+                            会員でない方も商品の閲覧はできますが<br>
+                            購入には会員登録が必要になります。
+      </p>
+      <h2>新着商品</h2>
+      <div class="row">
+        <% @new_item.each do |item| %>
+          <div class="col-md-3">
+          <%= link_to item_path(item.id) do %>
+            <%= image_tag item.get_image, size:'100x100' %>
+          <% end %>
+            <br>
+            <%= item.name %><br>
+            ￥<%= item.price %>
+          </div>>
+        <% end %>
+      </div>
+      </div class="row text-right">
+       <div class="offset-9 col-3">
+        <%= link_to items_path do %>
+         すべての商品を見る>
+        <% end %>
+       </div>
+      </div>
+      
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
顧客側のトップページとアバウトページ、ジャンル検索欄の部分テンプレートを型だけ実装しました。機能面はまだです。またレイアウトも未調整です。